### PR TITLE
优化VirtualService的路由规则

### DIFF
--- a/pkg/component/router/istio/http/istio_handler.go
+++ b/pkg/component/router/istio/http/istio_handler.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sort"
 	"strings"
 )
 
@@ -31,6 +32,9 @@ func VirtualService(namespace string, svcName string, availableLabels []string,
 	}
 	if len(serviceInfo.Hosts) > 0 {
 		virtualSvc.Spec.Hosts = serviceInfo.Hosts
+	}
+	if len(availableLabels) > 0 {
+		sort.Sort(sort.Reverse(sort.StringSlice(availableLabels)))
 	}
 	for _, port := range serviceInfo.Ports {
 		for _, label := range availableLabels {
@@ -213,7 +217,7 @@ func matchRoute(serviceName string, headerKey string, labelVal string, port uint
 		Match: []networkingv1alpha3.HTTPMatchRequest{{
 			Headers: map[string]v1alpha1.StringMatch{
 				headerKey: {
-					Exact: labelVal,
+					Prefix: labelVal,
 				},
 			},
 			Port: port,


### PR DESCRIPTION
根据环境亲缘性进行前缀匹配，适配namespace中不存在该环境标签的场景。